### PR TITLE
Add captured pieces display and chess timer with presets

### DIFF
--- a/clientside/css/style.css
+++ b/clientside/css/style.css
@@ -208,10 +208,88 @@ body {
   pointer-events: none;
 }
 
+/* Player bars (captured pieces + timer) */
+.player-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: min(80vw, 80vh);
+  min-height: 32px;
+  padding: 4px 6px;
+  background: #272522;
+  border-radius: 4px;
+}
+
+.captured-pieces {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1px;
+  min-height: 24px;
+}
+
+.captured-piece {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+  opacity: 0.9;
+}
+
+.material-advantage {
+  color: #aaa;
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-left: 4px;
+}
+
+/* Timers */
+.timer {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: #999;
+  background: #1a1816;
+  padding: 4px 12px;
+  border-radius: 4px;
+  min-width: 70px;
+  text-align: center;
+}
+
+.timer.timer-active {
+  color: #fff;
+  background: #3d8a4e;
+}
+
+.timer.timer-low {
+  color: #ff4444;
+}
+
+.timer.timer-active.timer-low {
+  background: #8a3d3d;
+  color: #ff6b6b;
+}
+
 /* Controls */
 .controls {
   display: flex;
   gap: 12px;
+  align-items: center;
+}
+
+.controls select {
+  padding: 8px 12px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  background: #272522;
+  color: #e0e0e0;
+  border: 2px solid #4a4744;
+  border-radius: 6px;
+  cursor: pointer;
+  appearance: auto;
+}
+
+.controls select:hover {
+  border-color: #6a6764;
 }
 
 .controls button {
@@ -232,4 +310,91 @@ body {
 
 .controls button:active {
   background: #347a43;
+}
+
+/* Custom time modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: #272522;
+  padding: 24px;
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: #e0e0e0;
+  min-width: 240px;
+}
+
+.modal-content h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.modal-content label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.9rem;
+}
+
+.modal-content input[type="number"] {
+  width: 60px;
+  padding: 4px 8px;
+  font-size: 0.95rem;
+  background: #1a1816;
+  color: #e0e0e0;
+  border: 2px solid #4a4744;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.modal-buttons {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.modal-buttons button {
+  padding: 6px 18px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+#custom-time-ok {
+  background: #4a9e5c;
+  color: white;
+}
+
+#custom-time-ok:hover {
+  background: #3d8a4e;
+}
+
+#custom-time-cancel {
+  background: #4a4744;
+  color: #ccc;
+}
+
+#custom-time-cancel:hover {
+  background: #5a5754;
 }

--- a/clientside/index.html
+++ b/clientside/index.html
@@ -9,10 +9,43 @@
 <body>
   <div class="app">
     <div id="status" class="status">White to move</div>
+
+    <div class="player-bar top-bar">
+      <div id="captured-by-white" class="captured-pieces"></div>
+      <div id="timer-black" class="timer">--:--</div>
+    </div>
+
     <div id="board" class="board"></div>
     <div id="promotion-modal" class="promotion-modal hidden"></div>
+
+    <div class="player-bar bottom-bar">
+      <div id="captured-by-black" class="captured-pieces"></div>
+      <div id="timer-white" class="timer">--:--</div>
+    </div>
+
     <div class="controls">
+      <select id="time-control">
+        <option value="0">No Timer</option>
+        <option value="60|0">Bullet 1+0</option>
+        <option value="180|2">Blitz 3+2</option>
+        <option value="300|0">Rapid 5+0</option>
+        <option value="600|0" selected>Rapid 10+0</option>
+        <option value="1800|0">Classical 30+0</option>
+        <option value="custom">Custom...</option>
+      </select>
       <button id="new-game">New Game</button>
+    </div>
+
+    <div id="custom-time-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Custom Time Control</h3>
+        <label>Minutes per side: <input type="number" id="custom-minutes" min="1" max="180" value="10"></label>
+        <label>Increment (sec): <input type="number" id="custom-increment" min="0" max="60" value="0"></label>
+        <div class="modal-buttons">
+          <button id="custom-time-ok">OK</button>
+          <button id="custom-time-cancel">Cancel</button>
+        </div>
+      </div>
     </div>
   </div>
   <script type="module" src="js/app.js"></script>

--- a/clientside/js/app.js
+++ b/clientside/js/app.js
@@ -1,31 +1,158 @@
 import { Game } from './game.js';
 import { Board } from './board.js';
+import { Timer } from './timer.js';
+
+const PIECE_ORDER = { q: 0, r: 1, b: 2, n: 3, p: 4 };
+const PIECE_VALUES = { q: 9, r: 5, b: 3, n: 3, p: 1 };
+const PIECE_DISPLAY = { k: 'K', q: 'Q', r: 'R', b: 'B', n: 'N', p: 'P' };
 
 const game = new Game();
 const statusEl = document.getElementById('status');
 const boardEl = document.getElementById('board');
 const promotionModal = document.getElementById('promotion-modal');
 const newGameBtn = document.getElementById('new-game');
+const capturedByWhiteEl = document.getElementById('captured-by-white');
+const capturedByBlackEl = document.getElementById('captured-by-black');
+const timerWhiteEl = document.getElementById('timer-white');
+const timerBlackEl = document.getElementById('timer-black');
+const timeControlSelect = document.getElementById('time-control');
+const customTimeModal = document.getElementById('custom-time-modal');
+const customMinutesInput = document.getElementById('custom-minutes');
+const customIncrementInput = document.getElementById('custom-increment');
+const customTimeOk = document.getElementById('custom-time-ok');
+const customTimeCancel = document.getElementById('custom-time-cancel');
 
 const board = new Board(boardEl, game, promotionModal);
+const timer = new Timer(timerWhiteEl, timerBlackEl);
 
-function updateStatus() {
-  statusEl.textContent = game.getGameStatus();
+let moveCount = 0;
+
+function renderCaptured() {
+  const captured = game.getCaptured();
+
+  for (const [color, el] of [['w', capturedByWhiteEl], ['b', capturedByBlackEl]]) {
+    const pieces = [...captured[color]].sort((a, b) => PIECE_ORDER[a] - PIECE_ORDER[b]);
+    el.innerHTML = '';
+
+    for (const p of pieces) {
+      const img = document.createElement('img');
+      img.className = 'captured-piece';
+      // White captured these pieces, so they are black pieces (opponent's color)
+      const victimColor = color === 'w' ? 'b' : 'w';
+      img.src = `img/pieces/${victimColor}${PIECE_DISPLAY[p]}.svg`;
+      img.alt = p;
+      el.appendChild(img);
+    }
+
+    // Material advantage
+    const myTotal = captured[color].reduce((s, p) => s + PIECE_VALUES[p], 0);
+    const oppColor = color === 'w' ? 'b' : 'w';
+    const oppTotal = captured[oppColor].reduce((s, p) => s + PIECE_VALUES[p], 0);
+    const diff = myTotal - oppTotal;
+    if (diff > 0) {
+      const badge = document.createElement('span');
+      badge.className = 'material-advantage';
+      badge.textContent = `+${diff}`;
+      el.appendChild(badge);
+    }
+  }
+}
+
+function updateStatus(msg) {
+  statusEl.textContent = msg || game.getGameStatus();
   statusEl.className = 'status';
-  if (game.isGameOver()) {
+  if (game.isGameOver() || msg) {
     statusEl.classList.add('game-over');
   } else if (game.getGameStatus().startsWith('Check')) {
     statusEl.classList.add('in-check');
   }
 }
 
-board.onMove(() => updateStatus());
+function getTimeConfig() {
+  const val = timeControlSelect.value;
+  if (val === '0' || val === 'custom') return null;
+  const [sec, inc] = val.split('|').map(Number);
+  return { seconds: sec, increment: inc };
+}
 
-newGameBtn.addEventListener('click', () => {
+function startNewGame() {
   game.newGame();
   board.render();
+  moveCount = 0;
+
+  const config = getTimeConfig();
+  if (config) {
+    timer.configure(config.seconds, config.increment);
+  } else {
+    timer.configure(0, 0);
+  }
+
+  updateStatus();
+  renderCaptured();
+}
+
+board.onMove((result) => {
+  moveCount++;
+  renderCaptured();
+
+  if (timer.isEnabled()) {
+    const currentTurn = game.getTurn();
+    if (moveCount === 1) {
+      // First move: start black's timer (white just moved)
+      timer.start(currentTurn);
+    } else {
+      timer.switchTo(currentTurn);
+    }
+  }
+
+  if (game.isGameOver()) {
+    timer.stop();
+  }
+
   updateStatus();
 });
 
+timer.onTimeout((loser) => {
+  const winner = loser === 'White' ? 'Black' : 'White';
+  updateStatus(`Time out! ${winner} wins`);
+});
+
+newGameBtn.addEventListener('click', startNewGame);
+
+// Time control select
+timeControlSelect.addEventListener('change', () => {
+  if (timeControlSelect.value === 'custom') {
+    customTimeModal.classList.remove('hidden');
+  }
+});
+
+customTimeOk.addEventListener('click', () => {
+  const minutes = parseInt(customMinutesInput.value, 10) || 10;
+  const increment = parseInt(customIncrementInput.value, 10) || 0;
+  // Add custom option and select it
+  const existingCustom = timeControlSelect.querySelector('[data-custom]');
+  if (existingCustom) existingCustom.remove();
+  const opt = document.createElement('option');
+  opt.value = `${minutes * 60}|${increment}`;
+  opt.textContent = `Custom ${minutes}+${increment}`;
+  opt.dataset.custom = 'true';
+  opt.selected = true;
+  timeControlSelect.insertBefore(opt, timeControlSelect.querySelector('[value="custom"]'));
+  customTimeModal.classList.add('hidden');
+});
+
+customTimeCancel.addEventListener('click', () => {
+  customTimeModal.classList.add('hidden');
+  timeControlSelect.value = '600|0'; // fallback to Rapid 10+0
+});
+
+// Initial render
 board.render();
 updateStatus();
+renderCaptured();
+
+// Configure initial timer (Rapid 10+0 default)
+const initConfig = getTimeConfig();
+if (initConfig) {
+  timer.configure(initConfig.seconds, initConfig.increment);
+}

--- a/clientside/js/game.js
+++ b/clientside/js/game.js
@@ -4,11 +4,13 @@ class Game {
   constructor() {
     this.chess = new Chess();
     this._lastMove = null;
+    this._captured = { w: [], b: [] }; // pieces captured BY each color
   }
 
   newGame() {
     this.chess.reset();
     this._lastMove = null;
+    this._captured = { w: [], b: [] };
   }
 
   makeMove(from, to, promotion) {
@@ -23,6 +25,11 @@ class Game {
     }
 
     this._lastMove = { from, to };
+
+    // Track captured pieces — result.color is the color that moved
+    if (result.captured) {
+      this._captured[result.color].push(result.captured);
+    }
 
     return {
       success: true,
@@ -87,6 +94,10 @@ class Game {
 
   getLastMove() {
     return this._lastMove;
+  }
+
+  getCaptured() {
+    return this._captured;
   }
 }
 

--- a/clientside/js/timer.js
+++ b/clientside/js/timer.js
@@ -1,0 +1,121 @@
+class Timer {
+  constructor(whiteEl, blackEl) {
+    this.whiteEl = whiteEl;
+    this.blackEl = blackEl;
+    this._interval = null;
+    this._running = false;
+    this._activeSide = null;
+    this._time = { w: 0, b: 0 }; // remaining time in ms
+    this._increment = 0; // increment in ms
+    this._lastTick = null;
+    this._onTimeout = null;
+    this._enabled = false;
+  }
+
+  configure(seconds, increment) {
+    this.stop();
+    if (seconds <= 0) {
+      this._enabled = false;
+      this.whiteEl.textContent = '--:--';
+      this.blackEl.textContent = '--:--';
+      this.whiteEl.classList.remove('timer-low', 'timer-active');
+      this.blackEl.classList.remove('timer-low', 'timer-active');
+      return;
+    }
+    this._enabled = true;
+    this._time.w = seconds * 1000;
+    this._time.b = seconds * 1000;
+    this._increment = increment * 1000;
+    this._activeSide = null;
+    this._render();
+  }
+
+  isEnabled() {
+    return this._enabled;
+  }
+
+  start(side) {
+    if (!this._enabled) return;
+    this._activeSide = side;
+    this._lastTick = performance.now();
+    this._running = true;
+    this._updateActiveClasses();
+
+    if (this._interval) clearInterval(this._interval);
+    this._interval = setInterval(() => this._tick(), 100);
+  }
+
+  switchTo(side) {
+    if (!this._enabled || !this._running) return;
+
+    // Add increment to the side that just moved (opposite of new active)
+    const movedSide = side === 'w' ? 'b' : 'w';
+    this._time[movedSide] += this._increment;
+
+    this._activeSide = side;
+    this._lastTick = performance.now();
+    this._updateActiveClasses();
+    this._render();
+  }
+
+  stop() {
+    this._running = false;
+    if (this._interval) {
+      clearInterval(this._interval);
+      this._interval = null;
+    }
+    this.whiteEl.classList.remove('timer-active');
+    this.blackEl.classList.remove('timer-active');
+  }
+
+  onTimeout(callback) {
+    this._onTimeout = callback;
+  }
+
+  _tick() {
+    if (!this._running || !this._activeSide) return;
+
+    const now = performance.now();
+    const elapsed = now - this._lastTick;
+    this._lastTick = now;
+
+    this._time[this._activeSide] -= elapsed;
+
+    if (this._time[this._activeSide] <= 0) {
+      this._time[this._activeSide] = 0;
+      this.stop();
+      this._render();
+      if (this._onTimeout) {
+        const loser = this._activeSide === 'w' ? 'White' : 'Black';
+        this._onTimeout(loser);
+      }
+      return;
+    }
+
+    this._render();
+  }
+
+  _render() {
+    this.whiteEl.textContent = this._formatTime(this._time.w);
+    this.blackEl.textContent = this._formatTime(this._time.b);
+
+    // Low time warning (under 30 seconds)
+    this.whiteEl.classList.toggle('timer-low', this._time.w > 0 && this._time.w < 30000);
+    this.blackEl.classList.toggle('timer-low', this._time.b > 0 && this._time.b < 30000);
+  }
+
+  _updateActiveClasses() {
+    this.whiteEl.classList.toggle('timer-active', this._activeSide === 'w');
+    this.blackEl.classList.toggle('timer-active', this._activeSide === 'b');
+  }
+
+  _formatTime(ms) {
+    if (ms <= 0) return '0:00';
+    const totalSeconds = Math.ceil(ms / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  }
+}
+
+export { Timer };


### PR DESCRIPTION
- Captured pieces shown above/below board with material advantage indicator
- Timer with presets: Bullet 1+0, Blitz 3+2, Rapid 5+0/10+0, Classical 30+0
- Custom time control modal for user-defined minutes + increment
- Timer starts after first move, switches on each turn with increment
- Low time warning (red) when under 30 seconds
- No Timer option available for untimed play

https://claude.ai/code/session_01GQCHs2X97yjP5ui4xip6Gb