### PR TITLE
Add smooth animations for piece captures

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -439,3 +439,44 @@ body {
 .footer a:hover {
   color: #888;
 }
+
+/* Piece animations */
+.piece.animating {
+  position: absolute !important;
+  z-index: 100;
+  transition: transform 0.3s cubic-bezier(0.4, 0.0, 0.2, 1);
+  will-change: transform;
+}
+
+.piece.capturing {
+  animation: captureAnimation 0.4s cubic-bezier(0.4, 0.0, 0.2, 1) forwards;
+}
+
+@keyframes captureAnimation {
+  0% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.15) rotate(5deg);
+  }
+  100% {
+    transform: scale(0.7) translateY(-20px);
+    opacity: 0;
+  }
+}
+
+.captured-piece.animating-in {
+  animation: slideInCaptured 0.3s ease-out;
+}
+
+@keyframes slideInCaptured {
+  from {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 0.9;
+  }
+}


### PR DESCRIPTION
Implemented visual animations when pieces take each other:
- Added CSS keyframes for capture animations (fade + scale effect)
- Created _animateMove() method to handle piece movement animations
- Modified _executeMove() to animate before updating board state
- Pieces now smoothly slide to target square over 300ms
- Captured pieces fade out with a scaling effect
- Works for both regular moves and pawn promotions

https://claude.ai/code/session_01GQCHs2X97yjP5ui4xip6Gb