### PR TITLE
Stockfish Version Display

### DIFF
--- a/js/ai.js
+++ b/js/ai.js
@@ -15,6 +15,7 @@ class AI {
     this._thinking = false;
     this._resolveMove = null;
     this._rejectMove = null;
+    this._engineName = 'Stockfish';
   }
 
   /**
@@ -35,6 +36,10 @@ class AI {
 
       this._worker.onmessage = (e) => {
         const line = typeof e.data === 'string' ? e.data : String(e.data);
+
+        if (line.startsWith('id name ')) {
+          this._engineName = line.substring(8);
+        }
 
         if (line === 'uciok') {
           uciReady = true;
@@ -103,6 +108,13 @@ class AI {
    */
   getElo(turn) {
     return turn === 'w' ? this._whiteElo : this._blackElo;
+  }
+
+  /**
+   * Get the engine name reported during UCI handshake
+   */
+  getEngineName() {
+    return this._engineName;
   }
 
   /**

--- a/js/app.js
+++ b/js/app.js
@@ -285,8 +285,8 @@ function startNewGame() {
   playerIconBlack.textContent = bIsAI ? '🤖' : '👤';
   const wEloVal = parseInt(aiWhiteEloSlider.value, 10);
   const bEloVal = parseInt(aiBlackEloSlider.value, 10);
-  const wName = wIsAI ? 'Stockfish' : (customWhiteName || 'Human');
-  const bName = bIsAI ? 'Stockfish' : (customBlackName || 'Human');
+  const wName = wIsAI ? ai.getEngineName() : (customWhiteName || 'Human');
+  const bName = bIsAI ? ai.getEngineName() : (customBlackName || 'Human');
   playerNameWhite.textContent = wName;
   playerNameBlack.textContent = bName;
   playerEloWhite.textContent = wIsAI ? wEloVal : '';
@@ -306,12 +306,12 @@ function startNewGame() {
     timeControl: getTimeControlLabel(),
     startingFen: game.chess.fen(),
     white: {
-      name: wIsAI ? `Stockfish ${wEloVal}` : wName,
+      name: wIsAI ? `${ai.getEngineName()} ${wEloVal}` : wName,
       isAI: wIsAI,
       elo: wIsAI ? wEloVal : null,
     },
     black: {
-      name: bIsAI ? `Stockfish ${bEloVal}` : bName,
+      name: bIsAI ? `${ai.getEngineName()} ${bEloVal}` : bName,
       isAI: bIsAI,
       elo: bIsAI ? bEloVal : null,
     },


### PR DESCRIPTION
## Summary
- Parse the engine's `id name` response during UCI initialization to capture the full engine name (e.g. "Stockfish 17.1 Lite WASM")
- Display the real engine name in the player info bar instead of hardcoded "Stockfish"
- Store the full engine name with ELO in game database records

## Changes
- **js/ai.js**: Added `_engineName` field, UCI `id name` parsing in handshake, `getEngineName()` method
- **js/app.js**: Replaced hardcoded `'Stockfish'` with `ai.getEngineName()` in player names and database records

## Test plan
- [x] Verified engine name displays as "Stockfish 17.1 Lite WASM" in player bar
- [x] Verified desktop layout — name fits alongside ELO and timer
- [x] Verified mobile layout — name wraps cleanly, no overflow
- [x] Verified both-AI mode shows correct name for both players
- [x] Verified database records include full engine name

🤖 Generated with [Claude Code](https://claude.com/claude-code)