### PR TITLE
Arrow Overlays for Analysis

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -109,6 +109,18 @@ body {
   touch-action: none;
   user-select: none;
   flex-shrink: 0;
+  position: relative;
+}
+
+/* Arrow overlay */
+.arrow-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 50;
 }
 
 /* Squares */

--- a/js/app.js
+++ b/js/app.js
@@ -300,6 +300,7 @@ function startNewGame() {
 
   const chess960 = chess960Toggle.checked;
   game.newGame(chess960);
+  board.getArrowOverlay().clear();
   board.render();
   moveCount = 0;
 
@@ -1068,6 +1069,9 @@ function exitReplayMode(startNew = true) {
   replayMoveDetails = [];
   replayClockSnapshots = [];
 
+  // Clear all arrows
+  board.getArrowOverlay().clear();
+
   // Re-enable board input and remove replay border
   board.setInteractive(true);
   boardEl.classList.remove('replay-mode-border');
@@ -1111,10 +1115,13 @@ function replayGoToMove(plyIndex) {
   }
   statusEl.className = 'status replay-mode';
 
-  // Update analysis detail panel for current ply
+  // Update analysis detail panel and engine arrows for current ply
   if (replayAnalysisData) {
     updateAnalysisDetail();
     updateCriticalNav();
+    updateEngineArrows();
+  } else {
+    board.getArrowOverlay().clearEngineArrows();
   }
 }
 
@@ -1479,8 +1486,9 @@ function setMainBoardAnalysis(result) {
   // Update critical moment nav
   updateCriticalNav();
 
-  // Show detail for current move
+  // Show detail and engine arrows for current move
   updateAnalysisDetail();
+  updateEngineArrows();
 }
 
 function addClassificationIcons() {
@@ -1612,6 +1620,20 @@ function updateAnalysisDetail() {
     replayLineEl.textContent = `Line: ${line}`;
   } else {
     replayLineEl.textContent = '';
+  }
+}
+
+function updateEngineArrows() {
+  const overlay = board.getArrowOverlay();
+  overlay.clearEngineArrows();
+
+  if (!replayAnalysisData) return;
+  const posIdx = replayPly + 1;
+  if (posIdx < 0 || posIdx >= replayAnalysisData.positions.length) return;
+
+  const pos = replayAnalysisData.positions[posIdx];
+  if (pos.bestMoveUci) {
+    overlay.setEngineArrows(pos.bestMoveUci, pos.bestLineUci || []);
   }
 }
 

--- a/js/arrows.js
+++ b/js/arrows.js
@@ -1,0 +1,211 @@
+const SVG_NS = 'http://www.w3.org/2000/svg';
+const FILES = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+const RANKS = ['8', '7', '6', '5', '4', '3', '2', '1'];
+
+const COLORS = {
+  engineBest: '#3b82f6',
+  enginePV:   '#93c5fd',
+  user:       '#dc2626',
+};
+
+class ArrowOverlay {
+  constructor(boardEl) {
+    this._boardEl = boardEl;
+    this._svg = null;
+    this._engineGroup = null;
+    this._userGroup = null;
+    this._userArrows = [];     // { from, to, element }
+    this._userHighlights = []; // { square, element }
+    this._createSVG();
+  }
+
+  /* ── Public API ─────────────────────────────────────── */
+
+  setEngineArrows(bestMoveUci, bestLineUci) {
+    this.clearEngineArrows();
+    if (!bestMoveUci) return;
+
+    const best = this._parseUci(bestMoveUci);
+    if (best) {
+      this._drawArrow(this._engineGroup, best.from, best.to,
+        COLORS.engineBest, 0.8, 0.25, 'arrow-engine');
+    }
+
+    // PV continuation: moves 2-4 (indices 1-3 of bestLineUci)
+    if (bestLineUci && bestLineUci.length > 1) {
+      const maxPV = Math.min(bestLineUci.length, 4);
+      for (let i = 1; i < maxPV; i++) {
+        const pv = this._parseUci(bestLineUci[i]);
+        if (pv) {
+          this._drawArrow(this._engineGroup, pv.from, pv.to,
+            COLORS.enginePV, 0.5, 0.18, 'arrow-pv');
+        }
+      }
+    }
+  }
+
+  clearEngineArrows() {
+    if (this._engineGroup) {
+      this._engineGroup.innerHTML = '';
+    }
+  }
+
+  addUserArrow(from, to) {
+    // Toggle off if duplicate
+    const idx = this._userArrows.findIndex(a => a.from === from && a.to === to);
+    if (idx !== -1) {
+      this._userArrows[idx].element.remove();
+      this._userArrows.splice(idx, 1);
+      return;
+    }
+
+    const el = this._drawArrow(this._userGroup, from, to,
+      COLORS.user, 0.75, 0.22, 'arrow-user');
+    this._userArrows.push({ from, to, element: el });
+  }
+
+  toggleHighlight(square) {
+    const idx = this._userHighlights.findIndex(h => h.square === square);
+    if (idx !== -1) {
+      this._userHighlights[idx].element.remove();
+      this._userHighlights.splice(idx, 1);
+      return;
+    }
+
+    const el = this._drawHighlight(this._userGroup, square, COLORS.user, 0.4);
+    this._userHighlights.push({ square, element: el });
+  }
+
+  clearUserAnnotations() {
+    for (const a of this._userArrows) a.element.remove();
+    for (const h of this._userHighlights) h.element.remove();
+    this._userArrows = [];
+    this._userHighlights = [];
+  }
+
+  clear() {
+    this.clearEngineArrows();
+    this.clearUserAnnotations();
+  }
+
+  destroy() {
+    if (this._svg && this._svg.parentNode) {
+      this._svg.remove();
+    }
+  }
+
+  /* ── SVG Setup ──────────────────────────────────────── */
+
+  _createSVG() {
+    this._svg = document.createElementNS(SVG_NS, 'svg');
+    this._svg.setAttribute('viewBox', '0 0 8 8');
+    this._svg.classList.add('arrow-overlay');
+
+    // Marker definitions
+    const defs = document.createElementNS(SVG_NS, 'defs');
+    defs.appendChild(this._createMarker('arrow-engine', COLORS.engineBest));
+    defs.appendChild(this._createMarker('arrow-pv', COLORS.enginePV));
+    defs.appendChild(this._createMarker('arrow-user', COLORS.user));
+    this._svg.appendChild(defs);
+
+    // Layer groups — engine below user
+    this._engineGroup = document.createElementNS(SVG_NS, 'g');
+    this._engineGroup.classList.add('engine-arrows');
+    this._svg.appendChild(this._engineGroup);
+
+    this._userGroup = document.createElementNS(SVG_NS, 'g');
+    this._userGroup.classList.add('user-annotations');
+    this._svg.appendChild(this._userGroup);
+
+    this._boardEl.appendChild(this._svg);
+  }
+
+  _createMarker(id, color) {
+    const marker = document.createElementNS(SVG_NS, 'marker');
+    marker.setAttribute('id', id);
+    marker.setAttribute('viewBox', '0 0 10 10');
+    marker.setAttribute('refX', '8');
+    marker.setAttribute('refY', '5');
+    marker.setAttribute('markerWidth', '3');
+    marker.setAttribute('markerHeight', '3');
+    marker.setAttribute('orient', 'auto-start-reverse');
+
+    const path = document.createElementNS(SVG_NS, 'path');
+    path.setAttribute('d', 'M 0 0 L 10 5 L 0 10 z');
+    path.setAttribute('fill', color);
+    marker.appendChild(path);
+
+    return marker;
+  }
+
+  /* ── Drawing Helpers ────────────────────────────────── */
+
+  _drawArrow(group, from, to, color, opacity, width, markerId) {
+    const fromCoords = this._squareToCoords(from);
+    const toCoords = this._squareToCoords(to);
+    if (!fromCoords || !toCoords) return null;
+
+    // Shorten endpoint so arrowhead doesn't cover piece center
+    const shortened = this._shortenLine(
+      fromCoords.x, fromCoords.y,
+      toCoords.x, toCoords.y, 0.2
+    );
+
+    const line = document.createElementNS(SVG_NS, 'line');
+    line.setAttribute('x1', fromCoords.x);
+    line.setAttribute('y1', fromCoords.y);
+    line.setAttribute('x2', shortened.x);
+    line.setAttribute('y2', shortened.y);
+    line.setAttribute('stroke', color);
+    line.setAttribute('stroke-opacity', opacity);
+    line.setAttribute('stroke-width', width);
+    line.setAttribute('stroke-linecap', 'round');
+    line.setAttribute('marker-end', `url(#${markerId})`);
+
+    group.appendChild(line);
+    return line;
+  }
+
+  _drawHighlight(group, square, color, opacity) {
+    const coords = this._squareToCoords(square);
+    if (!coords) return null;
+
+    const rect = document.createElementNS(SVG_NS, 'rect');
+    rect.setAttribute('x', coords.x - 0.5);
+    rect.setAttribute('y', coords.y - 0.5);
+    rect.setAttribute('width', 1);
+    rect.setAttribute('height', 1);
+    rect.setAttribute('fill', color);
+    rect.setAttribute('fill-opacity', opacity);
+    rect.setAttribute('rx', '0.05');
+
+    group.appendChild(rect);
+    return rect;
+  }
+
+  /* ── Coordinate Helpers ─────────────────────────────── */
+
+  _squareToCoords(square) {
+    if (!square || square.length < 2) return null;
+    const fileIdx = FILES.indexOf(square[0]);
+    const rankIdx = RANKS.indexOf(square[1]);
+    if (fileIdx === -1 || rankIdx === -1) return null;
+    return { x: fileIdx + 0.5, y: rankIdx + 0.5 };
+  }
+
+  _parseUci(uci) {
+    if (!uci || uci.length < 4) return null;
+    return { from: uci.substring(0, 2), to: uci.substring(2, 4) };
+  }
+
+  _shortenLine(x1, y1, x2, y2, amount) {
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    if (len < amount * 2) return { x: x2, y: y2 };
+    const ratio = (len - amount) / len;
+    return { x: x1 + dx * ratio, y: y1 + dy * ratio };
+  }
+}
+
+export { ArrowOverlay };


### PR DESCRIPTION
## Summary

Add arrow overlays on the chess board for engine best-move visualization and user annotations:

- **Engine arrows (blue):** Automatically shown during analysis/replay mode. Thick blue arrow for best move + lighter blue arrows for PV continuation (up to 3 moves).
- **User arrows (red):** Right-click-drag draws red arrows for commentary. Right-click a square for red highlight. Left-click or move clears user annotations.

## Implementation

- New `js/arrows.js` — `ArrowOverlay` class using SVG overlay with `viewBox="0 0 8 8"` for automatic scaling
- Modified `js/board.js` — right-click event handlers, arrow integration
- Modified `js/app.js` — engine arrows wired into replay/analysis flow
- Modified `css/style.css` — overlay positioning

## Test Plan

- [x] SVG overlay renders correctly on top of board
- [x] User arrows via right-click-drag (red)
- [x] Square highlights via right-click (red)
- [x] Clear on left-click and move execution
- [x] Arrow toggle (same arrow twice removes it)
- [x] Engine arrows appear during analysis/replay
- [x] Engine arrows update per move with best move + PV
- [x] User + engine arrows coexist
- [x] No console errors
- [x] Arrows scale with board resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)