### PR TITLE
Fix 0% accuracy on game loss

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chess-client",
-  "version": "1.05.0000",
+  "version": "1.05.0001",
   "private": true,
   "description": "Chess client — static site with vanilla JavaScript"
 }


### PR DESCRIPTION
## Summary
- Fix bug where post-game accuracy showed 0% when a player lost
- Replace harsh linear accuracy formula with win-probability-based formula (matches chess.com/lichess approach)
- Fix terminal position eval returning 0 instead of correct mate score
- Classify checkmating moves as "best" instead of penalizing them

## Changes
- `js/analysis.js`: Terminal position eval fix, checkmating move classification, win-probability accuracy formula
- `package.json`: Version bump 1.05.0000 → 1.05.0001
- `CACHE_VERSION` bumped from 2 to 3 to invalidate stale cached analysis

## Test plan
- [x] Unit tests pass (win probability, accuracy formula, checkmate handling)
- [x] Playwright visual tests with screenshots
- [ ] Manual AI vs AI game testing with mismatched ELOs

🤖 Generated with [Claude Code](https://claude.com/claude-code)