### PR TITLE
Fix tile-cam UI wiring, tint mask, and Safari controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -420,6 +420,18 @@ body {
   object-fit: cover;
 }
 
+.tile-cam-video::-webkit-media-controls {
+  display: none !important;
+}
+
+.tile-cam-video::-webkit-media-controls-panel {
+  display: none !important;
+}
+
+.tile-cam-video::-webkit-media-controls-start-playback-button {
+  display: none !important;
+}
+
 /* Color tint overlays for turn indication — clipped to matching square colour */
 .tile-cam-light-tint {
   position: absolute;
@@ -428,8 +440,8 @@ body {
   opacity: 0.55;
   pointer-events: none;
   transition: opacity 0.3s ease;
-  -webkit-mask: repeating-conic-gradient(#000 0% 25%, transparent 0% 50%) 0 0 / 12.5% 12.5%;
-  mask: repeating-conic-gradient(#000 0% 25%, transparent 0% 50%) 0 0 / 12.5% 12.5%;
+  -webkit-mask: repeating-conic-gradient(#000 0% 25%, transparent 0% 50%) 0 0 / 25% 25%;
+  mask: repeating-conic-gradient(#000 0% 25%, transparent 0% 50%) 0 0 / 25% 25%;
 }
 
 .tile-cam-dark-tint {
@@ -439,8 +451,8 @@ body {
   opacity: 0.55;
   pointer-events: none;
   transition: opacity 0.3s ease;
-  -webkit-mask: repeating-conic-gradient(transparent 0% 25%, #000 0% 50%) 0 0 / 12.5% 12.5%;
-  mask: repeating-conic-gradient(transparent 0% 25%, #000 0% 50%) 0 0 / 12.5% 12.5%;
+  -webkit-mask: repeating-conic-gradient(transparent 0% 25%, #000 0% 50%) 0 0 / 25% 25%;
+  mask: repeating-conic-gradient(transparent 0% 25%, #000 0% 50%) 0 0 / 25% 25%;
 }
 
 /* When tile cam is active, make square backgrounds transparent */

--- a/js/multiplayer-ui.js
+++ b/js/multiplayer-ui.js
@@ -11,9 +11,9 @@
  * waiting. When the opponent joins, the panel transitions to full lobby
  * mode (ready buttons, color swap).
  */
-const CAM_LABELS = { 'board-face': 'Board - Face', 'king-cam': 'King - Cam', 'split-cam': 'Side / Side', 'split-cam-h': 'Top / Bottom', 'none': 'No-Cam' };
-const CAM_LABELS_SHORT = { 'board-face': 'Board Face', 'split-cam': 'Side / Side', 'split-cam-h': 'Top / Bottom', 'king-cam': 'King Cam', 'none': 'No Cam' };
-const CAM_MODES = ['board-face', 'king-cam', 'split-cam', 'split-cam-h', 'none'];
+const CAM_LABELS = { 'board-face': 'Board - Face', 'tile-cam': 'Tile - Cam', 'king-cam': 'King - Cam', 'split-cam': 'Side / Side', 'split-cam-h': 'Top / Bottom', 'none': 'No-Cam' };
+const CAM_LABELS_SHORT = { 'board-face': 'Board Face', 'tile-cam': 'Tile Cam', 'split-cam': 'Side / Side', 'split-cam-h': 'Top / Bottom', 'king-cam': 'King Cam', 'none': 'No Cam' };
+const CAM_MODES = ['board-face', 'tile-cam', 'king-cam', 'split-cam', 'split-cam-h', 'none'];
 
 export class MultiplayerUI {
   constructor(mp) {

--- a/js/ui-controller.js
+++ b/js/ui-controller.js
@@ -25,7 +25,7 @@ export class UIController {
 
   constructor({
     game, board, db, mp, gameCtrl, settingsCtrl, replayController, liveMoveBar,
-    diagnostics, videoChat, videoBoard, splitCam, splitCamH, kingCam,
+    diagnostics, videoChat, videoBoard, tileCam, splitCam, splitCamH, kingCam,
     getVideoActive,
     callbacks,
     dom,
@@ -42,6 +42,7 @@ export class UIController {
     this.diagnostics = diagnostics;
     this.videoChat = videoChat;
     this.videoBoard = videoBoard;
+    this.tileCam = tileCam;
     this.splitCam = splitCam;
     this.splitCamH = splitCamH;
     this.kingCam = kingCam;
@@ -513,6 +514,7 @@ export class UIController {
     this.diagnostics.camModeChanged(mode);
     if (mode === 'king-cam') {
       this.videoBoard.disable();
+      this.tileCam.disable();
       this.splitCam.disable();
       this.splitCamH.disable();
       // Restore raw camera track — videoBoard replaced it with a cropped canvas stream that is now stopped
@@ -525,6 +527,7 @@ export class UIController {
       this.board.render();
     } else if (mode === 'board-face') {
       this.kingCam.disable();
+      this.tileCam.disable();
       this.splitCam.disable();
       this.splitCamH.disable();
       this.board.render();
@@ -536,6 +539,7 @@ export class UIController {
     } else if (mode === 'split-cam') {
       this.kingCam.disable();
       this.videoBoard.disable();
+      this.tileCam.disable();
       this.splitCamH.disable();
       this.board.render();
       // Restore raw camera track — videoBoard may have replaced it
@@ -547,15 +551,25 @@ export class UIController {
       this.kingCam.disable();
       this.videoBoard.disable();
       this.splitCam.disable();
+      this.tileCam.disable();
       this.board.render();
       // Restore raw camera track — videoBoard may have replaced it
       const rawVideoTrack = this.videoChat._localStream?.getVideoTracks()[0];
       if (rawVideoTrack) this.videoChat.replaceVideoTrack(rawVideoTrack);
       this.splitCamH.enable(this.videoChat._localStream, this.videoChat._remoteStream, this.mp.color);
       this.splitCamH.setTintEnabled(true);
+    } else if (mode === 'tile-cam') {
+      this.kingCam.disable();
+      this.videoBoard.disable();
+      this.splitCam.disable();
+      this.splitCamH.disable();
+      this.board.render();
+      this.tileCam.enable(this.videoChat._localStream, this.videoChat._remoteStream, this.mp.color);
+      this.tileCam.setTintEnabled(true);
     } else {
       this.kingCam.disable();
       this.videoBoard.disable();
+      this.tileCam.disable();
       this.splitCam.disable();
       this.splitCamH.disable();
       // Restore raw camera track when disabling all video modes


### PR DESCRIPTION
## Summary
- Add `tile-cam` to `CAM_MODES` and `CAM_LABELS` in `multiplayer-ui.js` so the lobby button cycles through it
- Wire `tileCam` into `UIController` constructor and `applyCamMode()` switch logic
- Fix tint overlay CSS mask size from `12.5%` to `25%` — was creating a 2x2 sub-pattern per square instead of 1:1 alignment with board squares
- Hide Safari's default video play/pause controls on tile-cam video elements

## Test plan
- [ ] In lobby, cycle cam modes — tile-cam should appear between board-face and king-cam
- [ ] With tile-cam active, each square should show one video feed with correct board color tint (not 4 sub-tiles)
- [ ] On Safari, no play/pause button overlay on video tiles